### PR TITLE
Add a comment when run on Dependabot PRs themselves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,8 @@ jobs:
           github-token: ${{ secrets.FRECKLE_AUTOMATION_GITHUB_TOKEN }}
           github-repository: freckle/megarepo
           dry-run: 1
+
+      # Finally run as if we were a Dependabot-PR, so we can see the comment
+      - uses: ./
+        with:
+          github-actor: 'dependabot[bot]'

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ implements.
 
 ```yaml
 on:
+  # When run on a Dependabot PR itself, we will leave a comment to indicate that
+  # we will be automatically handling this PR for you.
+  pull_request:
+
+  # Otherwise, we will search and handle any open Dependabot PRs
   schedule:
     # ...
 

--- a/action.yml
+++ b/action.yml
@@ -58,4 +58,5 @@ runs:
         GH_REPO: ${{ inputs.github-repository }}
         GH_EVENT: ${{ github.event_name }}
         GH_PR_ACTION: ${{ github.event.action }}
+        GH_PR_NUMBER: ${{ github.event.number }}
         GH_PR_TITLE: ${{ github.event.pull_request.title }}

--- a/action.yml
+++ b/action.yml
@@ -57,5 +57,5 @@ runs:
         GH_ACTOR: ${{ inputs.github-actor }}
         GH_REPO: ${{ inputs.github-repository }}
         GH_EVENT: ${{ github.event_name }}
-        GH_PR_ACTION: ${{ github.event.pull_request.action }}
+        GH_PR_ACTION: ${{ github.event.action }}
         GH_PR_TITLE: ${{ github.event.pull_request.title }}

--- a/action.yml
+++ b/action.yml
@@ -41,12 +41,12 @@ runs:
   steps:
     - name: Auto-merge Dependabot PRs
       shell: bash
-      run: |
-        export GITHUB_TOKEN=${{ inputs.github-token }}
-        export DRY_RUN=${{ inputs.dry-run }}
+      run: ${{ github.action_path }}/bin/automerge-prs
+      env:
+        EXCLUDE_TITLE_REGEX: ${{ inputs.exclude-title-regex }}
+        QUARANTINE_DAYS: ${{ inputs.quarantine-days }}
+        STRATEGY: ${{ inputs.strategy }}
+        DRY_RUN: ${{ inputs.dry-run }}
 
-        ${{ github.action_path }}/bin/automerge-prs \
-          ${{ inputs.github-repository }} \
-          ${{ inputs.quarantine-days }} \
-          ${{ inputs.strategy }} \
-          '${{ inputs.exclude-title-regex }}'
+        GH_TOKEN: ${{ inputs.github-token }}
+        GH_REPO: ${{ inputs.github-repository }}

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,11 @@ inputs:
     required: true
     default: rebase
 
+  github-actor:
+    description: "Override GitHub actor. This is mostly useful in testing."
+    required: true
+    default: "${{ github.actor }}"
+
   github-repository:
     description: "Override GitHub repository, if necessary"
     required: true
@@ -49,4 +54,8 @@ runs:
         DRY_RUN: ${{ inputs.dry-run }}
 
         GH_TOKEN: ${{ inputs.github-token }}
+        GH_ACTOR: ${{ inputs.github-actor }}
         GH_REPO: ${{ inputs.github-repository }}
+        GH_EVENT: ${{ github.event_name }}
+        GH_PR_ACTION: ${{ github.event.pull_request.action }}
+        GH_PR_TITLE: ${{ github.event.pull_request.title }}

--- a/bin/automerge-prs
+++ b/bin/automerge-prs
@@ -36,7 +36,7 @@ if is_dependabot && ! exclude_by_title "$GH_PR_TITLE"; then
 
   case "$GH_PR_ACTION" in
     opened)
-      cat >"$tmp" <<EOM
+      cat >"$tmp/message" <<EOM
 :heavy_check_mark: If all status checks pass, and no other reviews are submitted, [mergeabot][] will merge this PR after $QUARANTINE_DAYS day(s), on $until.
 
 As long as that's OK, no other action is necessary.
@@ -45,7 +45,7 @@ As long as that's OK, no other action is necessary.
 EOM
       ;;
     *)
-      cat >"$tmp" <<EOM
+      cat >"$tmp/message" <<EOM
 :clock1: Resetting [mergeabot][] another $QUARANTINE_DAYS day(s) to $until.
 
 [mergeabot]: https://github.com/freckle/mergeabot-action
@@ -53,7 +53,7 @@ EOM
       ;;
   esac
 
-  gh pr comment "$GH_PR" --body-file "$tmp"
+  gh pr comment "$GH_PR" --body-file "$tmp/message"
   exit 0
 fi
 

--- a/bin/automerge-prs
+++ b/bin/automerge-prs
@@ -3,37 +3,26 @@ set -euo pipefail
 
 shopt -s nullglob
 
-if [[ -z "${GITHUB_TOKEN:-""}" ]]; then
-  echo "GITHUB_TOKEN not set" >&2
-  exit 1
-fi
-
-if (($# < 3)); then
-  echo "Usage: automerge-prs <owner/repo> <quarantine-days> <strategy> [exclude-title-regex]" >&2
-  exit 64
-fi
-
-repo=$1
-quarantine_days=$2
-strategy=$3
-exclude_title_regex=${4:-""}
-
-if [[ ! "$strategy" =~ merge|rebase|squash ]]; then
+if [[ ! "$STRATEGY" =~ merge|rebase|squash ]]; then
   echo "Invalid strategy: must be merge, rebase, or squash" >&2
   exit 64
 fi
 
 : "${DRY_RUN:=0}"
 
+exclude_by_title() {
+  [[ -n "$EXCLUDE_TITLE_REGEX" ]] && [[ "$1" =~ $EXCLUDE_TITLE_REGEX ]]
+}
+
 gh_pr() {
-  gh pr --repo "$repo" "$@"
+  gh pr --repo "$GH_REPO" "$@"
 }
 
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 
 now_s=$(date +"%s")
-since_s=$((now_s - (quarantine_days * 24 * 60 * 60)))
+since_s=$((now_s - (QUARANTINE_DAYS * 24 * 60 * 60)))
 since=$(date -d "@$since_s" +"%Y-%m-%d")
 
 search="author:app/dependabot updated:<$since"
@@ -58,7 +47,7 @@ for json in "$tmp"/*.json; do
   printf '  Last updated: \e[35m%s\e[0m\n' "$updatedAt"
   printf '  Current review decision: \e[35m%s\e[0m\n' "$reviewDecision"
 
-  if [[ -n "$exclude_title_regex" ]] && [[ "$title" =~ $exclude_title_regex ]]; then
+  if exclude_by_title "$title"; then
     printf '  \e[1;37m=>\e[0m \e[33mSkip\e[0m (title matches exclude-title-regex)\n'
     continue
   fi
@@ -70,14 +59,14 @@ for json in "$tmp"/*.json; do
     APPROVED)
       printf '  \e[1;37m=>\e[0m \e[32mEnable auto-merge\e[0m\n'
       if ((!DRY_RUN)); then
-        gh_pr merge --auto "$number" --"$strategy"
+        gh_pr merge --auto "$number" --"$STRATEGY"
       fi
       ;;
     *)
       printf '  \e[1;37m=>\e[0m \e[32mApprove and enable auto-merge\e[0m\n'
       if ((!DRY_RUN)); then
         gh_pr review --approve "$number"
-        gh_pr merge --auto "$number" --"$strategy"
+        gh_pr merge --auto "$number" --"$STRATEGY"
       fi
       ;;
   esac

--- a/bin/automerge-prs
+++ b/bin/automerge-prs
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
 shopt -s nullglob
 
 if [[ ! "$STRATEGY" =~ merge|rebase|squash ]]; then
@@ -9,6 +8,17 @@ if [[ ! "$STRATEGY" =~ merge|rebase|squash ]]; then
 fi
 
 : "${DRY_RUN:=0}"
+
+: "${GH_ACTOR:=""}"
+: "${GH_EVENT:=""}"
+: "${GH_PR_ACTION:=""}"
+: "${GH_PR_TITLE:=""}"
+
+is_dependabot() {
+  [[ "$GH_ACTOR" == 'dependabot[bot]' ]] &&
+    [[ "$GH_EVENT" == 'pull_request' ]] &&
+    [[ "$GH_PR_ACTION" == 'opened' ]]
+}
 
 exclude_by_title() {
   [[ -n "$EXCLUDE_TITLE_REGEX" ]] && [[ "$1" =~ $EXCLUDE_TITLE_REGEX ]]
@@ -20,6 +30,21 @@ gh_pr() {
 
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
+
+if is_dependabot && ! exclude_by_title "$GH_PR_TITLE"; then
+  cat >"$tmp" <<EOM
+This project uses [mergeabot][]. If all status checks pass, this PR will
+be automatically merged after $QUARANTINE_DAYS day(s). Any action taken on the PR
+will reset the clock.
+
+[mergeabot]: https://github.com/freckle/mergeabot-action
+
+As long as that's OK, no review is necessary.
+EOM
+
+  gh pr comment "$GH_PR" --body-file "$tmp"
+  exit 0
+fi
 
 now_s=$(date +"%s")
 since_s=$((now_s - (QUARANTINE_DAYS * 24 * 60 * 60)))

--- a/bin/automerge-prs
+++ b/bin/automerge-prs
@@ -12,6 +12,7 @@ fi
 : "${GH_ACTOR:=""}"
 : "${GH_EVENT:=""}"
 : "${GH_PR_ACTION:=""}"
+: "${GH_PR_NUMBER:=""}"
 : "${GH_PR_TITLE:=""}"
 
 is_dependabot() {
@@ -53,7 +54,7 @@ EOM
       ;;
   esac
 
-  gh pr comment "$GH_PR" --body-file "$tmp/message"
+  gh pr comment "$GH_PR_NUMBER" --body-file "$tmp/message"
   exit 0
 fi
 

--- a/bin/automerge-prs
+++ b/bin/automerge-prs
@@ -15,9 +15,7 @@ fi
 : "${GH_PR_TITLE:=""}"
 
 is_dependabot() {
-  [[ "$GH_ACTOR" == 'dependabot[bot]' ]] &&
-    [[ "$GH_EVENT" == 'pull_request' ]] &&
-    [[ "$GH_PR_ACTION" == 'opened' ]]
+  [[ "$GH_ACTOR" == 'dependabot[bot]' ]] && [[ "$GH_EVENT" == 'pull_request' ]]
 }
 
 exclude_by_title() {
@@ -32,15 +30,28 @@ tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 
 if is_dependabot && ! exclude_by_title "$GH_PR_TITLE"; then
-  cat >"$tmp" <<EOM
-This project uses [mergeabot][]. If all status checks pass, this PR will
-be automatically merged after $QUARANTINE_DAYS day(s). Any action taken on the PR
-will reset the clock.
+  now_s=$(date +"%s")
+  until_s=$((now_s + (QUARANTINE_DAYS * 24 * 60 * 60)))
+  until=$(date -d "@$until_s" +"%Y-%m-%d")
+
+  case "$GH_PR_ACTION" in
+    opened)
+      cat >"$tmp" <<EOM
+:heavy_check_mark: If all status checks pass, and no other reviews are submitted, [mergeabot][] will merge this PR after $QUARANTINE_DAYS day(s), on $until.
+
+As long as that's OK, no other action is necessary.
 
 [mergeabot]: https://github.com/freckle/mergeabot-action
-
-As long as that's OK, no review is necessary.
 EOM
+      ;;
+    *)
+      cat >"$tmp" <<EOM
+:clock1: Resetting [mergeabot][] another $QUARANTINE_DAYS day(s) to $until.
+
+[mergeabot]: https://github.com/freckle/mergeabot-action
+EOM
+      ;;
+  esac
 
   gh pr comment "$GH_PR" --body-file "$tmp"
   exit 0


### PR DESCRIPTION
Closes #1.

Teams will still get tasked with reviewing Dependabot PRs. In a
mergeabot project, that is unnecessary. However, it's hard to know if
you are in a mergeabot project or not when pulled into such a PR. Adding
this comment on the `opened` event should get folks to stand down.

Ideally, you'd be able to prevent the review assignment by `CODEOWNERS`
on Dependabot PRs, but that doesn't seem like a feature GitHub will
build.