### PR TITLE
Remove review requests from Dependabot PRs when opened

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,12 @@ jobs:
       # Run as if we were a Dependabot-PR, so we can see the comment
       - uses: ./
         with:
+          remove-reviewers: false
           github-actor: 'dependabot[bot]'
 
       # And test the when-message conditional
       - uses: ./
         with:
           quarantine-days: -1
+          remove-reviewers: false
           github-actor: 'dependabot[bot]'

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,11 @@ inputs:
     required: true
     default: rebase
 
+  remove-reviewers:
+    description: Remove any reviewers from Dependabot PRs when they open?
+    required: true
+    default: true
+
   github-actor:
     description: "Override GitHub actor. This is mostly useful in testing."
     required: true
@@ -51,6 +56,7 @@ runs:
         EXCLUDE_TITLE_REGEX: ${{ inputs.exclude-title-regex }}
         QUARANTINE_DAYS: ${{ inputs.quarantine-days }}
         STRATEGY: ${{ inputs.strategy }}
+        REMOVE_REVIEWERS: ${{ inputs.remove-reviewers }}
         DRY_RUN: ${{ inputs.dry-run }}
 
         GH_TOKEN: ${{ inputs.github-token }}

--- a/bin/automerge-prs
+++ b/bin/automerge-prs
@@ -42,6 +42,11 @@ if is_dependabot && ! exclude_by_title "$GH_PR_TITLE"; then
 
   case "$GH_PR_ACTION" in
     opened)
+      if [[ "$REMOVE_REVIEWERS" == 'true' ]]; then
+        echo "Removing review requests"
+        gh api --repo "$GH_REPO" -X DELETE "repos/{owner}/{repo}/pulls/$GH_PR_NUMBER/review_requests"
+      fi
+
       cat >"$tmp/message" <<EOM
 :heavy_check_mark: If all status checks pass, and no other reviews are submitted, [mergeabot][] will merge this PR $when_message."
 


### PR DESCRIPTION
If we plan to handle with mergeabot, reviewers are not required and in
fact confuse them. I think the comment is still valuable because the
reviewers will still end up notified and subscribed before we remove
them. Without the comment, it might be more confusing to just be removed
without any indication of anything.

An option was added to disable this behavior for when we pretend to
treat our own PRs as Dependabot to test that path -- we want normal
review on them.
