### PR TITLE
Report PRs with required status failures

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,12 +44,20 @@ inputs:
     required: true
     default: 0
 
-outputs: {}
+outputs:
+  failed:
+    description: "Was mergeabot unable to process any PRs?"
+    value: ${{ steps.automerge.outputs.failed }}
+
+  failed-urls:
+    description: "List of PRs which were unable to be processed"
+    value: ${{ steps.automerge.outputs.failed-urls }}
 
 runs:
   using: composite
   steps:
-    - name: Auto-merge Dependabot PRs
+    - id: automerge
+      name: Auto-merge Dependabot PRs
       shell: bash
       run: ${{ github.action_path }}/bin/automerge-prs
       env:

--- a/bin/automerge-prs
+++ b/bin/automerge-prs
@@ -20,6 +20,9 @@ shopt -s nullglob
 : "${GH_PR_TITLE:=""}"
 : "${GH_PR_HEAD_REF:=""}"
 
+# Actions interface
+: "${GITHUB_OUTPUT:=/dev/null}"
+
 if [[ ! "$STRATEGY" =~ merge|rebase|squash ]]; then
   echo "Invalid strategy: must be merge, rebase, or squash" >&2
   exit 64
@@ -88,12 +91,20 @@ EOM
   exit 0
 fi
 
+read -r defaultBranch < \
+  <(gh repo view "$GH_REPO" --json defaultBranchRef --jq '.defaultBranchRef.name')
+
+gh api \
+  "/repos/$GH_REPO/branches/$defaultBranch/protection" \
+  --jq '.required_status_checks.contexts[]' |
+  sort >"$tmp/required-statuses.txt"
+
 now_s=$(date +"%s")
 since_s=$((now_s - (QUARANTINE_DAYS * 24 * 60 * 60)))
 since=$(date -d "@$since_s" +"%Y-%m-%d")
 
 search="author:app/dependabot updated:<$since"
-fields='number,title,headRefName,author,updatedAt,reviewDecision'
+fields='number,title,headRefName,author,updatedAt,reviewDecision,statusCheckRollup'
 
 gh_pr list --search "$search" --limit 1000 --json "$fields" --jq '.[]' |
   while IFS=$'\n' read -r ln; do
@@ -102,6 +113,7 @@ gh_pr list --search "$search" --limit 1000 --json "$fields" --jq '.[]' |
   done
 
 found=0
+failed=()
 
 for json in "$tmp"/*.json; do
   number=$(jq --raw-output '.number' "$json")
@@ -125,6 +137,27 @@ for json in "$tmp"/*.json; do
     continue
   fi
 
+  jq --raw-output '.statusCheckRollup[] | select(.conclusion=="FAILURE") | .name' "$json" | sort >"$tmp/$number-failed-statuses.txt"
+  comm -12 "$tmp/required-statuses.txt" "$tmp/$number-failed-statuses.txt" >"$tmp/$number-required-failed-statuses.txt"
+
+  read -r failedStatuses < <(paste -sd ' ' "$tmp/$number-required-failed-statuses.txt")
+  read -r failedStatusesCount < <(wc -l <"$tmp/$number-required-failed-statuses.txt")
+
+  if ((failedStatusesCount == 1)); then
+    statusesHave='status has'
+  else
+    statusesHave='statuses have'
+  fi
+
+  if [[ -n "$failedStatuses" ]]; then
+    failed+=("$number")
+    printf '  \e[1;31m!!\e[0m %d required %s failed: \e[35m%s\e[0m\n' \
+      "$failedStatusesCount" \
+      "$statusesHave" \
+      "$failedStatuses"
+    continue
+  fi
+
   case "$reviewDecision" in
     CHANGES_REQUESTED)
       printf '  \e[1;37m=>\e[0m \e[33mSkip\e[0m (changes requested)\n'
@@ -144,6 +177,17 @@ for json in "$tmp"/*.json; do
       ;;
   esac
 done
+
+if ((${#failed})); then
+  echo "Warning: the following PRs cannot be auto-merged:"
+  echo "failed=true" >>"$GITHUB_OUTPUT"
+  echo "failed-urls<<EOM" >>"$GITHUB_OUTPUT"
+  for number in "${failed[@]}"; do
+    printf 'https://github.com/%s/pull/%s\n' "$GH_REPO" "$number"
+  done | tee -a "$GITHUB_OUTPUT"
+  echo "EOM" >>"$GITHUB_OUTPUT"
+
+fi
 
 if ((!found)); then
   echo "No Dependabot PRs found older than $since."

--- a/bin/automerge-prs
+++ b/bin/automerge-prs
@@ -2,12 +2,16 @@
 set -euo pipefail
 shopt -s nullglob
 
-if [[ ! "$STRATEGY" =~ merge|rebase|squash ]]; then
-  echo "Invalid strategy: must be merge, rebase, or squash" >&2
-  exit 64
-fi
+# Matches action defaults
+: "${EXCLUDE_TITLE_REGEX:=""}"
+: "${QUARANTINE_DAYS:=5}"
+: "${STRATEGY:=rebase}"
+: "${REMOVE_REVIEWERS:=true}"
 
-: "${DRY_RUN:=0}"
+# Except DRY_RUN=1 is better default if being run locally
+: "${DRY_RUN:=1}"
+
+# required: GH_REPO
 
 : "${GH_ACTOR:=""}"
 : "${GH_EVENT:=""}"
@@ -15,6 +19,11 @@ fi
 : "${GH_PR_NUMBER:=""}"
 : "${GH_PR_TITLE:=""}"
 : "${GH_PR_HEAD_REF:=""}"
+
+if [[ ! "$STRATEGY" =~ merge|rebase|squash ]]; then
+  echo "Invalid strategy: must be merge, rebase, or squash" >&2
+  exit 64
+fi
 
 is_dependabot() {
   [[ "$GH_ACTOR" == 'dependabot[bot]' ]] && [[ "$GH_EVENT" == 'pull_request' ]]


### PR DESCRIPTION
### [Default variables in-script too](https://github.com/freckle/mergeabot-action/pull/12/commits/19024e88ff2b5e3fe7ebd35cf30ace72a548c7c8)
[19024e8](https://github.com/freckle/mergeabot-action/pull/12/commits/19024e88ff2b5e3fe7ebd35cf30ace72a548c7c8)

This makes it easier to test locally. The defaults now match the
defaults in `action.yml`, except for `DRY_RUN`, naturally.

### [Report PRs with required status failures](https://github.com/freckle/mergeabot-action/pull/12/commits/995ab99abe20fe74d005d2b7db3dc87fda7a5b75)
[995ab99](https://github.com/freckle/mergeabot-action/pull/12/commits/995ab99abe20fe74d005d2b7db3dc87fda7a5b75)

Assuming PRs are left to mergeabot, these failures would never be
visible to the team since the reviewer has been removed and the
assumption is that the PR will pass and be merged eventually.

We raise visibility in 3 ways here:

1. Report on each PR which required statuses failed, if any
2. Report at the end the list of such PRs
3. Set `failed` and `failed-urls` outputs for further action