### PR TITLE
Reverse order of approve-enable

### DIFF
--- a/bin/automerge-prs
+++ b/bin/automerge-prs
@@ -119,7 +119,7 @@ for json in "$tmp"/*.json; do
       fi
       ;;
     *)
-      printf '  \e[1;37m=>\e[0m \e[32mApprove and enable auto-merge\e[0m\n'
+      printf '  \e[1;37m=>\e[0m \e[32mEnable auto-merge and approve\e[0m\n'
       if ((!DRY_RUN)); then
         gh_pr merge --auto "$number" --"$STRATEGY"
         gh_pr review --approve "$number"

--- a/bin/automerge-prs
+++ b/bin/automerge-prs
@@ -121,8 +121,8 @@ for json in "$tmp"/*.json; do
     *)
       printf '  \e[1;37m=>\e[0m \e[32mApprove and enable auto-merge\e[0m\n'
       if ((!DRY_RUN)); then
-        gh_pr review --approve "$number"
         gh_pr merge --auto "$number" --"$STRATEGY"
+        gh_pr review --approve "$number"
       fi
       ;;
   esac


### PR DESCRIPTION
If our approval made the PR mergeable (aka "clean status"), then
enabling auto-merge fails.

This should actually be the case often, but we usually succeed because
we do the two actions so quickly. Presumably, GitHub's own state has not
updated yet. Sometimes it does, and we see an error about it.

Reversing the order of operations will produce the same outcome, but
should guarantee the PR is not in clean status when we enable auto-merge
(since it is waiting for our own Approve).

Fixes #15.
