### PR TITLE
feat: make PR author configurable to support Renovate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,11 @@ jobs:
           remove-reviewers: false
           github-actor: 'dependabot[bot]'
 
-      # Run as if we were a Renovate-PR, to exercise the multiline pr-authors input
+      # Run as if we were a Renovate-PR, to exercise the multiline bot-authors input
       - uses: ./
         with:
           remove-reviewers: false
           github-actor: 'renovate[bot]'
-          pr-authors: |
+          bot-authors: |
             dependabot[bot]
             renovate[bot]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,12 @@ jobs:
           quarantine-days: -1
           remove-reviewers: false
           github-actor: 'dependabot[bot]'
+
+      # Run as if we were a Renovate-PR, to exercise the multiline pr-authors input
+      - uses: ./
+        with:
+          remove-reviewers: false
+          github-actor: 'renovate[bot]'
+          pr-authors: |
+            dependabot[bot]
+            renovate[bot]

--- a/README.md
+++ b/README.md
@@ -117,6 +117,16 @@ jobs:
   `squash`. Default is `rebase`.
 - `remove-reviewers`: remove any requested reviewers (if run on PRs). Default
   is `true`.
+- `pr-authors`: which dependency-bot PR authors to act on, one bot login per
+  line. Default is `dependabot[bot]`. To also handle Renovate:
+
+  ```yaml
+  - uses: freckle/mergeabot-action@v2
+    with:
+      pr-authors: |
+        dependabot[bot]
+        renovate[bot]
+  ```
 
 See [`action.yml`](./action.yml) for other, seldom useful, inputs.
 

--- a/README.md
+++ b/README.md
@@ -117,13 +117,13 @@ jobs:
   `squash`. Default is `rebase`.
 - `remove-reviewers`: remove any requested reviewers (if run on PRs). Default
   is `true`.
-- `pr-authors`: which dependency-bot PR authors to act on, one bot login per
+- `bot-authors`: which dependency-bot PR authors to act on, one bot login per
   line. Default is `dependabot[bot]`. To also handle Renovate:
 
   ```yaml
   - uses: freckle/mergeabot-action@v2
     with:
-      pr-authors: |
+      bot-authors: |
         dependabot[bot]
         renovate[bot]
   ```

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,22 @@ inputs:
     default: rebase
 
   remove-reviewers:
-    description: Remove any reviewers from Dependabot PRs when they open?
+    description: Remove any reviewers from bot PRs when they open?
     required: true
     default: true
+
+  pr-authors:
+    description: |
+      Which dependency-bot PR authors to act on, one bot login per line.
+      Defaults to Dependabot only; set to
+
+        pr-authors: |
+          dependabot[bot]
+          renovate[bot]
+
+      to also handle Renovate.
+    required: true
+    default: "dependabot[bot]"
 
   github-actor:
     description: "Override GitHub actor. This is mostly useful in testing."
@@ -57,6 +70,7 @@ runs:
         QUARANTINE_DAYS: ${{ inputs.quarantine-days }}
         STRATEGY: ${{ inputs.strategy }}
         REMOVE_REVIEWERS: ${{ inputs.remove-reviewers }}
+        PR_AUTHORS: ${{ inputs.pr-authors }}
         DRY_RUN: ${{ inputs.dry-run }}
 
         GH_TOKEN: ${{ inputs.github-token }}
@@ -66,4 +80,3 @@ runs:
         GH_PR_ACTION: ${{ github.event.action }}
         GH_PR_NUMBER: ${{ github.event.number }}
         GH_PR_TITLE: ${{ github.event.pull_request.title }}
-        GH_PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}

--- a/action.yml
+++ b/action.yml
@@ -24,12 +24,12 @@ inputs:
     required: true
     default: true
 
-  pr-authors:
+  bot-authors:
     description: |
       Which dependency-bot PR authors to act on, one bot login per line.
       Defaults to Dependabot only; set to
 
-        pr-authors: |
+        bot-authors: |
           dependabot[bot]
           renovate[bot]
 
@@ -70,7 +70,7 @@ runs:
         QUARANTINE_DAYS: ${{ inputs.quarantine-days }}
         STRATEGY: ${{ inputs.strategy }}
         REMOVE_REVIEWERS: ${{ inputs.remove-reviewers }}
-        PR_AUTHORS: ${{ inputs.pr-authors }}
+        BOT_AUTHORS: ${{ inputs.bot-authors }}
         DRY_RUN: ${{ inputs.dry-run }}
 
         GH_TOKEN: ${{ inputs.github-token }}

--- a/bin/automerge-prs
+++ b/bin/automerge-prs
@@ -14,28 +14,49 @@ fi
 : "${GH_PR_ACTION:=""}"
 : "${GH_PR_NUMBER:=""}"
 : "${GH_PR_TITLE:=""}"
-: "${GH_PR_HEAD_REF:=""}"
 
-is_dependabot() {
-  [[ "$GH_ACTOR" == 'dependabot[bot]' ]] && [[ "$GH_EVENT" == 'pull_request' ]]
+# PR_AUTHORS is the configured set of dependency-bot logins to act on, one per
+# line (mirrors @actions/core's getMultilineInput: trim each line, drop empties).
+: "${PR_AUTHORS:=dependabot[bot]}"
+author_logins=()
+while IFS= read -r line; do
+  line="${line#"${line%%[![:space:]]*}"}" # ltrim
+  line="${line%"${line##*[![:space:]]}"}" # rtrim
+  [[ -n "$line" ]] && author_logins+=("$line")
+done <<<"$PR_AUTHORS"
+
+is_bot_pr_event() {
+  [[ "$GH_EVENT" == 'pull_request' ]] || return 1
+  local login
+  for login in "${author_logins[@]}"; do
+    [[ "$GH_ACTOR" == "$login" ]] && return 0
+  done
+  return 1
 }
 
 exclude_by_title() {
   [[ -n "$EXCLUDE_TITLE_REGEX" ]] && [[ "$1" =~ $EXCLUDE_TITLE_REGEX ]]
 }
 
-is_workflows_update() {
-  [[ "$1" =~ ^dependabot/github_actions/.* ]]
-}
-
 gh_pr() {
   gh pr --repo "$GH_REPO" "$@"
+}
+
+# True if any of the newline-separated file paths on stdin is a GitHub Actions
+# workflow file. Our token usually lacks the "workflows" permission to merge
+# such PRs, so we leave them for a human.
+touches_workflows() {
+  grep -q '^\.github/workflows/'
+}
+
+pr_touches_workflows() {
+  gh api --paginate "repos/$GH_REPO/pulls/$1/files" --jq '.[].filename' | touches_workflows
 }
 
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 
-if is_dependabot && ! exclude_by_title "$GH_PR_TITLE" && ! is_workflows_update "$GH_PR_HEAD_REF"; then
+if is_bot_pr_event && ! exclude_by_title "$GH_PR_TITLE" && ! pr_touches_workflows "$GH_PR_NUMBER"; then
   if ((QUARANTINE_DAYS <= 0)); then
     when_message="the next time it runs"
   else
@@ -75,8 +96,20 @@ now_s=$(date +"%s")
 since_s=$((now_s - (QUARANTINE_DAYS * 24 * 60 * 60)))
 since=$(date -d "@$since_s" +"%Y-%m-%d")
 
-search="author:app/dependabot updated:<$since"
-fields='number,title,headRefName,author,createdAt,reviewDecision'
+fields='number,title,author,createdAt,reviewDecision,files'
+
+# Build one search OR-ing each author, repeating the updated:< filter in every
+# branch: GitHub parses "A OR B C" as "A OR (B AND C)" and has no grouping
+# parentheses, so the quarantine window must be attached to each author. The
+# search author is "app/<slug>" for a "<slug>[bot]" App, else the bare login.
+search=""
+for login in "${author_logins[@]}"; do
+  case "$login" in
+    *'[bot]') author="app/${login%'[bot]'}" ;;
+    *) author="$login" ;;
+  esac
+  search+="${search:+ OR }author:$author updated:<$since"
+done
 
 gh_pr list --search "$search" --limit 1000 --json "$fields" --jq '.[]' |
   while IFS=$'\n' read -r ln; do
@@ -89,7 +122,6 @@ found=0
 for json in "$tmp"/*.json; do
   number=$(jq --raw-output '.number' "$json")
   title=$(jq --raw-output '.title' "$json")
-  branch=$(jq --raw-output '.headRefName' "$json")
   createdAt=$(jq --raw-output '.createdAt' "$json")
   reviewDecision=$(jq --raw-output '.reviewDecision' "$json")
   found=1
@@ -103,8 +135,8 @@ for json in "$tmp"/*.json; do
     continue
   fi
 
-  if is_workflows_update "$branch"; then
-    printf '  \e[1;37m=>\e[0m \e[33mSkip\e[0m (PR updates worflows)\n'
+  if jq -r '.files[]?.path' "$json" | touches_workflows; then
+    printf '  \e[1;37m=>\e[0m \e[33mSkip\e[0m (PR updates workflows)\n'
     continue
   fi
 
@@ -129,5 +161,5 @@ for json in "$tmp"/*.json; do
 done
 
 if ((!found)); then
-  echo "No Dependabot PRs found older than $since."
+  echo "No bot PRs found older than $since."
 fi

--- a/bin/automerge-prs
+++ b/bin/automerge-prs
@@ -15,15 +15,15 @@ fi
 : "${GH_PR_NUMBER:=""}"
 : "${GH_PR_TITLE:=""}"
 
-# PR_AUTHORS is the configured set of dependency-bot logins to act on, one per
+# BOT_AUTHORS is the configured set of dependency-bot logins to act on, one per
 # line (mirrors @actions/core's getMultilineInput: trim each line, drop empties).
-: "${PR_AUTHORS:=dependabot[bot]}"
+: "${BOT_AUTHORS:=dependabot[bot]}"
 author_logins=()
 while IFS= read -r line; do
   line="${line#"${line%%[![:space:]]*}"}" # ltrim
   line="${line%"${line##*[![:space:]]}"}" # rtrim
   [[ -n "$line" ]] && author_logins+=("$line")
-done <<<"$PR_AUTHORS"
+done <<<"$BOT_AUTHORS"
 
 is_bot_pr_event() {
   [[ "$GH_EVENT" == 'pull_request' ]] || return 1

--- a/bin/automerge-prs
+++ b/bin/automerge-prs
@@ -27,11 +27,7 @@ done <<<"$PR_AUTHORS"
 
 is_bot_pr_event() {
   [[ "$GH_EVENT" == 'pull_request' ]] || return 1
-  local login
-  for login in "${author_logins[@]}"; do
-    [[ "$GH_ACTOR" == "$login" ]] && return 0
-  done
-  return 1
+  grep -Fq " $GH_ACTOR " <<<" ${author_logins[*]} "
 }
 
 exclude_by_title() {
@@ -42,15 +38,14 @@ gh_pr() {
   gh pr --repo "$GH_REPO" "$@"
 }
 
-# True if any of the newline-separated file paths on stdin is a GitHub Actions
-# workflow file. Our token usually lacks the "workflows" permission to merge
-# such PRs, so we leave them for a human.
-touches_workflows() {
+any_workflow_path() {
   grep -q '^\.github/workflows/'
 }
 
+# True if the PR touches a GitHub Actions workflow file. Our token usually lacks
+# the "workflows" permission to merge such PRs, so we leave them for a human.
 pr_touches_workflows() {
-  gh api --paginate "repos/$GH_REPO/pulls/$1/files" --jq '.[].filename' | touches_workflows
+  gh api --paginate "repos/$GH_REPO/pulls/$1/files" --jq '.[].filename' | any_workflow_path
 }
 
 tmp=$(mktemp -d)
@@ -135,7 +130,7 @@ for json in "$tmp"/*.json; do
     continue
   fi
 
-  if jq -r '.files[]?.path' "$json" | touches_workflows; then
+  if jq -r '.files[]?.path' "$json" | any_workflow_path; then
     printf '  \e[1;37m=>\e[0m \e[33mSkip\e[0m (PR updates workflows)\n'
     continue
   fi


### PR DESCRIPTION
## Summary

Mergeabot's reviewer-removal ("quiet") behavior and scheduled auto-merge scan were hardcoded to Dependabot (`dependabot[bot]` actor + `author:app/dependabot` search). Renovate PRs were therefore left out and kept getting the round-robin review requests we want Mergeabot to absorb.

This replaces the hardcoded author with a configurable **`pr-authors`** input, so the same "remove reviewers + leave a guiding comment on open" treatment (and the scheduled auto-merge scan) applies to whatever dependency bots a consumer uses.

Inspired by [freckle/megarepo#45102](https://github.com/freckle/megarepo/pull/45102), but scoped to just the reviewer-removal half — no escalation logic here.

## Changes

- **`pr-authors` input** (`action.yml`): a multiline list of bot logins, one per line, parsed in bash the same way [`freckle/github-repo-health`](https://github.com/freckle/github-repo-health) uses `@actions/core`'s `getMultilineInput` (trim each line, drop empties). Default is `dependabot[bot]`, so existing consumers are unaffected.
- **`bin/automerge-prs`**: `is_dependabot` → `is_bot_pr_event`, matching the configured authors.
- **Scheduled scan OR-s the authors into a single search**, repeating the `updated:<` quarantine filter in each branch. GitHub parses `A OR B C` as `A OR (B AND C)` and has no grouping parentheses, so the filter must be attached to each author individually (verified against `freckle/megarepo`). The search author is derived per login: `app/<slug>` for a `<slug>[bot]` App, else the bare login.
- **Workflow-file PRs detected via the `/files` API** instead of a Dependabot-specific branch-name heuristic, so the check is bot-agnostic.
- README + a CI step exercising the multiline `pr-authors` input with a `renovate[bot]` actor.

## Usage

```yaml
- uses: freckle/mergeabot-action@v2
  with:
    pr-authors: |
      dependabot[bot]
      renovate[bot]
```

## Test plan

- [x] `bash -n` passes on `bin/automerge-prs`
- [x] Multiline parsing + author derivation verified locally (single author, two authors, indented/blank lines, non-bot actor)
- [x] OR search verified against `freckle/megarepo`: returns the union when in-window, and 0 when the per-branch `updated:<` filter excludes both (confirming the filter distributes correctly)
- [x] `touches_workflows` verified against real PR file lists (matches root `.github/workflows/`, ignores nested paths)
- [ ] CI green (exercises both Dependabot and Renovate actor paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)