### PR TITLE
feat: escalate failing bot PRs with no reviewer to the owning team

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,14 @@ jobs:
           bot-authors: |
             dependabot[bot]
             renovate[bot]
+
+      # Exercise escalation directly: the action gates it to scheduled runs, but
+      # CI runs on pull_request, so invoke the script with dry-run here.
+      - name: Escalation dry-run
+        run: ./bin/escalate-failing-prs
+        env:
+          DRY_RUN: 1
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          GH_REPO: freckle/megarepo
+          BOT_AUTHORS: renovate[bot]
+          ESCALATION_FALLBACK_TEAM: team-platform

--- a/README.md
+++ b/README.md
@@ -128,7 +128,49 @@ jobs:
         renovate[bot]
   ```
 
+- `escalate`: on scheduled runs, request a team reviewer on failing bot PRs that
+  have no reviewer (see [Escalation](#escalation)). Default is `false`.
+- `escalation-fallback-team`: team slug to request when CODEOWNERS resolves to
+  no team, or to more than one. Empty (the default) skips such PRs.
+- `escalation-team-prefix`: only CODEOWNERS owners of the form `@org/<prefix>*`
+  are treated as routable teams. Default is `team-`.
+- `codeowners-path`: CODEOWNERS file used for escalation routing. Default is
+  `.github/CODEOWNERS`.
+
 See [`action.yml`](./action.yml) for other, seldom useful, inputs.
+
+## Escalation
+
+Mergeabot removes reviewers from healthy bot PRs, so a requested reviewer should
+mean "this PR needs human attention." `escalate: true` restores the other half
+of that convention: on scheduled runs it finds bot PRs that have **failing
+statuses** (so they can never auto-merge) and **no reviewer**, requests the
+owning team as reviewer, and leaves a one-time triage comment.
+
+The owning team is resolved from `CODEOWNERS` against the PR's changed files
+(last match wins, gitignore-style globbing). Only `@org/<prefix>*` owners count
+as teams; a PR spanning multiple teams (or matching none) routes to
+`escalation-fallback-team`. Comments are idempotent (re-runs are no-ops).
+
+```yaml
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  mergeabot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: freckle/mergeabot-action@v2
+        with:
+          bot-authors: |
+            dependabot[bot]
+            renovate[bot]
+          escalate: true
+          escalation-fallback-team: team-platform
+          # github.token usually can't request team reviewers; pass an App token
+          github-token: ${{ steps.app-token.outputs.token }}
+```
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,34 @@ inputs:
     required: true
     default: 0
 
+  escalate:
+    description: |
+      On scheduled runs, request a team reviewer (and leave a triage comment)
+      on bot PRs that have failing statuses and no reviewer, so they don't sit
+      unmerged and unnoticed. Off by default. Requires a token that can request
+      team reviewers (e.g. a GitHub App token, not the default Actions token).
+    required: true
+    default: false
+
+  escalation-fallback-team:
+    description: |
+      Team slug to request when CODEOWNERS resolves to no team, or to more than
+      one (a PR spanning multiple teams). When empty, such PRs are skipped.
+    required: true
+    default: ""
+
+  escalation-team-prefix:
+    description: |
+      Only CODEOWNERS owners of the form @org/<prefix>* are treated as routable
+      teams (others, e.g. individuals, are ignored for routing).
+    required: true
+    default: "team-"
+
+  codeowners-path:
+    description: "Path to the CODEOWNERS file used for escalation routing"
+    required: true
+    default: ".github/CODEOWNERS"
+
 outputs: {}
 
 runs:
@@ -80,3 +108,18 @@ runs:
         GH_PR_ACTION: ${{ github.event.action }}
         GH_PR_NUMBER: ${{ github.event.number }}
         GH_PR_TITLE: ${{ github.event.pull_request.title }}
+
+    # Escalation is a scheduled sweep, not a per-PR-event reaction.
+    - name: Escalate failing bot PRs
+      if: ${{ inputs.escalate == 'true' && github.event_name != 'pull_request' }}
+      shell: bash
+      run: ${{ github.action_path }}/bin/escalate-failing-prs
+      env:
+        BOT_AUTHORS: ${{ inputs.bot-authors }}
+        ESCALATION_FALLBACK_TEAM: ${{ inputs.escalation-fallback-team }}
+        ESCALATION_TEAM_PREFIX: ${{ inputs.escalation-team-prefix }}
+        CODEOWNERS_PATH: ${{ inputs.codeowners-path }}
+        DRY_RUN: ${{ inputs.dry-run }}
+
+        GH_TOKEN: ${{ inputs.github-token }}
+        GH_REPO: ${{ inputs.github-repository }}

--- a/bin/escalate-failing-prs
+++ b/bin/escalate-failing-prs
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s nullglob
+
+# Restore the "a requested reviewer means this PR needs human attention"
+# invariant: find open bot PRs that have failing statuses (so they can never
+# auto-merge) and no reviewer, route them to the owning team via CODEOWNERS, and
+# leave a triage comment. Idempotent via a hidden HTML marker.
+
+: "${DRY_RUN:=0}"
+: "${CODEOWNERS_PATH:=.github/CODEOWNERS}"
+: "${ESCALATION_TEAM_PREFIX:=team-}"
+: "${ESCALATION_FALLBACK_TEAM:=}"
+: "${GH_REPO:?GH_REPO is required}"
+
+# BOT_AUTHORS is the configured set of dependency-bot logins to act on, one per
+# line (mirrors @actions/core's getMultilineInput: trim each line, drop empties).
+: "${BOT_AUTHORS:=dependabot[bot]}"
+author_logins=()
+while IFS= read -r line; do
+  line="${line#"${line%%[![:space:]]*}"}" # ltrim
+  line="${line%"${line##*[![:space:]]}"}" # rtrim
+  [[ -n "$line" ]] && author_logins+=("$line")
+done <<<"$BOT_AUTHORS"
+
+gh_pr() {
+  gh pr --repo "$GH_REPO" "$@"
+}
+
+MARKER='<!-- mergeabot-escalation -->'
+
+# statusCheckRollup conclusions/states that mean "this PR cannot merge as-is".
+# SUCCESS/SKIPPED/NEUTRAL/PENDING are intentionally excluded.
+FAILING='"FAILURE","ERROR","TIMED_OUT","CANCELLED","STARTUP_FAILURE","ACTION_REQUIRED"'
+
+# Convert a CODEOWNERS glob to an ERE using gitignore semantics. Patterns
+# starting with / are anchored to the repo root; others may match anywhere. A
+# trailing / is dropped, then re-added by the (/|$) suffix.
+codeowners_to_regex() {
+  local pattern="$1" anchored=0 p="" c i
+  if [[ "$pattern" == /* ]]; then
+    anchored=1
+    pattern="${pattern#/}"
+  fi
+  pattern="${pattern%/}"
+  # Escape ERE metacharacters char-by-char (portable; * is left for the globbing
+  # step below). Done in bash to avoid sed's bracket-expression portability quirks.
+  for ((i = 0; i < ${#pattern}; i++)); do
+    c="${pattern:i:1}"
+    case "$c" in
+      '.' | '+' | '^' | '$' | '(' | ')' | '{' | '}' | '|' | '[' | ']' | '\') p+="\\$c" ;;
+      *) p+="$c" ;;
+    esac
+  done
+  p=${p//\*\*/$'\x01'} # ** matches across /
+  p=${p//\*/[^/]*}     # * does not
+  p=${p//$'\x01'/.*}
+  if ((anchored)); then
+    printf '^%s(/|$)' "$p"
+  else
+    printf '(^|/)%s(/|$)' "$p"
+  fi
+}
+
+# Parse CODEOWNERS into parallel RULE_REGEX/RULE_TEAM arrays in file order.
+# RULE_TEAM holds the first team-prefixed owner for a rule, or "" when the rule
+# has none (e.g. an unowned path), so "last match wins" can override a catch-all.
+RULE_REGEX=()
+RULE_TEAM=()
+parse_codeowners() {
+  local content="$1" line trimmed pat team owner i
+  local team_owner_re="^@[^/]+/${ESCALATION_TEAM_PREFIX}"
+  while IFS= read -r line; do
+    trimmed="${line%$'\r'}"
+    trimmed="${trimmed#"${trimmed%%[![:space:]]*}"}"
+    [[ -z "$trimmed" || "$trimmed" == '#'* ]] && continue
+    # shellcheck disable=SC2206
+    local parts=($trimmed)
+    pat="${parts[0]}"
+    team=""
+    for ((i = 1; i < ${#parts[@]}; i++)); do
+      owner="${parts[i]}"
+      if [[ "$owner" =~ $team_owner_re ]]; then
+        team="${owner#@*/}" # strip @org/
+        break
+      fi
+    done
+    RULE_REGEX+=("$(codeowners_to_regex "$pat")")
+    RULE_TEAM+=("$team")
+  done <<<"$content"
+}
+
+# Team slug for a single path, or "" if the last matching rule has no team.
+team_for_path() {
+  local path="$1" result="" i
+  for ((i = 0; i < ${#RULE_REGEX[@]}; i++)); do
+    if [[ "$path" =~ ${RULE_REGEX[i]} ]]; then
+      result="${RULE_TEAM[i]}"
+    fi
+  done
+  printf '%s' "$result"
+}
+
+# Team to request for a PR given its changed paths: the single owning team if
+# they all agree, otherwise the fallback (also used when nothing matches).
+get_review_team() {
+  local f t teams="" uniq count
+  for f in "$@"; do
+    t="$(team_for_path "$f")"
+    [[ -n "$t" ]] && teams+="$t"$'\n'
+  done
+  uniq=$(printf '%s' "$teams" | grep -v '^$' | sort -u || true)
+  count=$(printf '%s\n' "$uniq" | grep -c . || true)
+  if [[ "$count" -eq 1 ]]; then
+    printf '%s' "$uniq"
+  else
+    printf '%s' "$ESCALATION_FALLBACK_TEAM"
+  fi
+}
+
+codeowners=""
+if codeowners=$(gh api "repos/$GH_REPO/contents/$CODEOWNERS_PATH" \
+  -H "Accept: application/vnd.github.raw" 2>/dev/null); then
+  parse_codeowners "$codeowners"
+  echo "Loaded ${#RULE_REGEX[@]} CODEOWNERS rule(s) from $CODEOWNERS_PATH"
+else
+  echo "Could not read $CODEOWNERS_PATH from $GH_REPO; using fallback team only"
+fi
+
+# All open bot PRs, OR-ing each configured author (no updated:< filter — a PR can
+# fail its checks at any age). No trailing AND term, so OR precedence is moot.
+search=""
+for login in "${author_logins[@]}"; do
+  case "$login" in
+    *'[bot]') author="app/${login%'[bot]'}" ;;
+    *) author="$login" ;;
+  esac
+  search+="${search:+ OR }author:$author"
+done
+
+prs_json=$(gh_pr list \
+  --state open \
+  --search "$search" \
+  --limit 1000 \
+  --json number,reviewRequests,statusCheckRollup,files)
+
+fail=0
+found=0
+
+while IFS=$'\t' read -r number files_str; do
+  [[ -z "$number" ]] && continue
+  found=1
+  # shellcheck disable=SC2206
+  files=($files_str)
+  team="$(get_review_team "${files[@]}")"
+
+  printf 'Failing bot PR (#\e[34m%s\e[0m)\n' "$number"
+  printf '  Routed to team: \e[35m%s\e[0m\n' "${team:-<none>}"
+
+  if [[ -z "$team" ]]; then
+    printf '  \e[1;37m=>\e[0m \e[33mSkip\e[0m (no team resolved and no fallback configured)\n'
+    continue
+  fi
+
+  if gh api --paginate "repos/$GH_REPO/issues/$number/comments" --jq '.[].body' 2>/dev/null |
+    grep -qF "$MARKER"; then
+    printf '  \e[1;37m=>\e[0m \e[33mSkip\e[0m (already escalated)\n'
+    continue
+  fi
+
+  if ((DRY_RUN)); then
+    printf '  \e[1;37m=>\e[0m \e[32m[dry-run] Would request %s and post escalation comment\e[0m\n' "$team"
+    continue
+  fi
+
+  printf '  \e[1;37m=>\e[0m \e[32mRequesting review from %s and posting comment\e[0m\n' "$team"
+  if ! echo "{\"team_reviewers\":[\"$team\"]}" |
+    gh api -X POST --input - "repos/$GH_REPO/pulls/$number/requested_reviewers" >/dev/null; then
+    echo "  Failed to request reviewer $team on #$number" >&2
+    fail=1
+    continue
+  fi
+
+  gh_pr comment "$number" --body-file - <<EOM
+$MARKER
+This bot PR has failing statuses and cannot auto-merge. It has been re-assigned for human intervention.
+
+If you are the new reviewer, you should:
+
+- [ ] Check for failing statuses and address any (click the status link on this PR for details)
+- [ ] Approve the PR
+EOM
+done < <(
+  printf '%s' "$prs_json" | jq -r "
+    .[]
+    | select((.reviewRequests | length) == 0)
+    | select(
+        [.statusCheckRollup[]? | (.conclusion // .state // \"\")]
+        | map(IN($FAILING))
+        | any
+      )
+    | \"\(.number)\t\([.files[]?.path] | join(\" \"))\"
+  "
+)
+
+if ((!found)); then
+  echo "No failing bot PRs without a reviewer found."
+fi
+
+if ((fail)); then
+  echo "Failed to escalate some PRs" >&2
+  exit 1
+fi


### PR DESCRIPTION
> **Stacked on #37** (base branch is `renovate-reviewer-automation`). Re-target to `main` once #37 merges; the diff will then show only the escalation changes.

## Summary

Mergeabot removes reviewers from healthy bot PRs, so a requested reviewer should mean *"this PR needs human attention."* This PR restores the other half of that invariant — the **escalation** behavior from [freckle/megarepo#45102](https://github.com/freckle/megarepo/pull/45102), generalized into the Action.

On scheduled runs, `escalate: true` finds open bot PRs (per `pr-authors`) that have **failing statuses** and **no reviewer**, resolves the owning team from `CODEOWNERS`, requests that team as reviewer, and leaves a one-time triage comment.

## Changes

- **`bin/escalate-failing-prs`** — new script. ORs the configured authors into one open-PR search (no `updated:` filter), then filters via JSON to PRs whose `statusCheckRollup` has a failing conclusion/state and whose `reviewRequests` is empty.
- **CODEOWNERS routing** — parsed at runtime: gitignore-style globbing compiled to ERE (pure bash, no `sed` portability traps), last-match-wins. Only `@org/<prefix>*` owners count as routable teams. A PR spanning multiple teams (or matching none) routes to `escalation-fallback-team`; if that's empty, the PR is skipped.
- **Idempotent** — every escalation comment carries a hidden `<!-- mergeabot-escalation -->` marker, so re-runs are no-ops.
- **New inputs**: `escalate` (default `false`), `escalation-fallback-team`, `escalation-team-prefix` (default `team-`), `codeowners-path` (default `.github/CODEOWNERS`).
- The escalation step is gated to non-`pull_request` events (it's a scheduled sweep, not a per-PR reaction).
- README + a CI dry-run step.

## Notes

- Requesting a **team** reviewer needs a token with org read — `github.token` usually can't, so pass a GitHub App token (matching megarepo's setup).
- No `check_suite` trigger; this is a daily sweep with up-to-~24h latency, same tradeoff as the megarepo version.

## Usage

```yaml
on:
  schedule:
    - cron: "0 0 * * *"

jobs:
  mergeabot:
    runs-on: ubuntu-latest
    steps:
      - uses: freckle/mergeabot-action@v2
        with:
          pr-authors: |
            dependabot[bot]
            renovate[bot]
          escalate: true
          escalation-fallback-team: team-platform
          github-token: ${{ steps.app-token.outputs.token }}
```

## Test plan

- [x] `bash -n` passes on `bin/escalate-failing-prs`
- [x] CODEOWNERS routing unit-tested against real `freckle/megarepo` CODEOWNERS (educator/platform paths, mid-pattern glob `educator-*`, multi-team → fallback, unknown → fallback)
- [x] Failing+no-reviewer jq filter unit-tested (selects failing/no-reviewer; excludes with-reviewer, passing, pending, empty-rollup)
- [x] End-to-end dry-run against `freckle/megarepo` (loads 29 CODEOWNERS rules, read-only)
- [ ] CI green
- [ ] Live verification of the request-reviewer + comment path on a real failing, reviewer-less PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)